### PR TITLE
Add last year GSoC DaemonSet project link

### DIFF
--- a/mentoring/gsoc/2025/project_ideas.md
+++ b/mentoring/gsoc/2025/project_ideas.md
@@ -48,7 +48,7 @@ If you are a GSoC candidate, please check out our [contributor guidance](../cont
 
 ### Daemonset mode for the Prometheus Agent
 
-- Description: During the [last GSoC](../2024/project_ideas.md), Prometheus Operator gained the option to deploy a `PrometheusAgent` custom resource as a DaemonSet (instead of the default StatefulSet mode). The project was a success and met its objectives but the feature is still behind a feature flag because not all the functionalities have been implemented. The expectations for this year are to identify the remaining gaps, write a plan of action, implement the missing features and write documentation (tutorials for instance).
+- Description: During the [last GSoC](../2024/project_ideas.md), Prometheus Operator gained the option to deploy a `PrometheusAgent` custom resource as a DaemonSet (instead of the default StatefulSet mode). The [project](https://summerofcode.withgoogle.com/archive/2024/projects/RD3xNW8g) was a success and met its objectives but the feature is still behind a feature flag because not all the functionalities have been implemented. The expectations for this year are to identify the remaining gaps, write a plan of action, implement the missing features and write documentation (tutorials for instance).
 - Recommended Skills: Go, Kubernetes
 - Expected project size: medium
 - Mentor(s):


### PR DESCRIPTION
Add last year GSoC DaemonSet project link to give mentees more info about what we achieved, and what need to be done next.